### PR TITLE
Html export update

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,14 +32,15 @@ exports.exportHtmlAdditionalTags = function(hook, pad, cb){
 };
 
 // line, apool,attribLine,text
-exports.getLineHTMLForExport = function (hook, line) {
-  var contextV = _analyzeLine(line.attribLine, line.apool);
+exports.getLineHTMLForExport = function (hook, context) {
+  var contextV = _analyzeLine(context.attribLine, context.apool);
 
   // If it has a context
   if(contextV){
     var contexts = contextV.split("$");
   }else{
-    return line.lineContent + "<br>";
+    context.lineContent = context.lineContent + "<br>";
+    return true;
   }
 
   var before = "";
@@ -77,10 +78,12 @@ exports.getLineHTMLForExport = function (hook, line) {
       after += "</p>";
     });
     // Remove leading * else don't..
-    var newString = before + line.lineContent.substring(1) + after + "<br>";
-    return newString;
-  }else{ // no context, nothing to remove
-    return line.lineContent;
+    if (context.lineContent[0] === '*') {
+      context.lineContent = context.lineContent.substring(1)
+    }
+    
+    context.lineContent = before + context.lineContent + after + "<br>";
+    return true;
   }
 }
 


### PR DESCRIPTION
This is an update to fix etherpad issues with html export and get ether/etherpad-lite#3268 merged into master: I actually didn't go to deep to understand what type/structure of input this plugin needs. It errored when I tried to drag/drop some html quote. After reading some code I tried a basic json from notepad dragdrop and finally got some lines out. So it would be great I description would have an example of input.